### PR TITLE
fix: await mongoose.connect so failures are caught

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,8 +1,8 @@
 const mongoose = require("mongoose");
 
-module.exports = () => {
+module.exports = async () => {
   try {
-    mongoose.connect(process.env.DB);
+    await mongoose.connect(process.env.DB);
     console.log("Connected to database successfully");
   } catch (error) {
     console.log(error);

--- a/db.js
+++ b/db.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 
-module.exports = async () => {
+module.exports = async function connectToDatabase() {
   try {
     await mongoose.connect(process.env.DB);
     console.log("Connected to database successfully");

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ app.use("/api/users", userRoutes);
 app.use("/api/auth", authRoutes);
 
 const port = process.env.PORT || 8080;
-app.listen(port, console.log(`Listening on port ${port}...`));
+app.listen(port, () => console.log(`Listening on port ${port}...`));
 
 // link static React build
 app.use(express.static("./client/build"));


### PR DESCRIPTION
## Server startup / DB connection fixes

Two small, self-contained correctness fixes in the Express entry path.

### 1. `db.js` — await mongoose.connect so failures are caught
Without `await`, the connect promise's rejection escaped the synchronous try/catch, so connection errors were never logged. Making the exporter async lets the catch handle them.

### 2. `index.js` — register listen callback instead of calling console.log eagerly
`app.listen(port, console.log(`Listening...`))` invoked `console.log` immediately at module load and passed its `undefined` return value as the "listening" callback. Result: the message printed before the server bound, and no listen callback was ever registered. Wrapped it in an arrow function so it fires once the server is actually listening.

Both are behavior-preserving beyond fixing the logging/error-handling timing; no API or route changes.